### PR TITLE
Added rate validation.

### DIFF
--- a/src/__tests__/RateFormat.test.js
+++ b/src/__tests__/RateFormat.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import RateFormat from '../components/RateFormat';
+
+describe('<RateFormat />', () => {
+  it('should render without crashing', () => {
+    const props = {
+      inputRef: () => {},
+      onChange: () => {},
+    };
+
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    const rendered = render(<RateFormat {...props} />);
+    expect(rendered).toBeTruthy();
+  });
+});

--- a/src/components/ForexRateEntry.js
+++ b/src/components/ForexRateEntry.js
@@ -5,7 +5,7 @@ import {
 } from '@material-ui/core';
 import { DateTime } from 'luxon';
 
-import RateFormat from './RateFormat'
+import RateFormat from './RateFormat';
 import DatePicker from './DatePicker';
 import ForexRateEndDateOption from './ForexRateEndDateOption';
 

--- a/src/components/ForexRateEntry.js
+++ b/src/components/ForexRateEntry.js
@@ -4,8 +4,8 @@ import {
   Grid, TextField, Typography, withStyles,
 } from '@material-ui/core';
 import { DateTime } from 'luxon';
-import NumberFormat from 'react-number-format';
 
+import RateFormat from './RateFormat'
 import DatePicker from './DatePicker';
 import ForexRateEndDateOption from './ForexRateEndDateOption';
 
@@ -48,27 +48,6 @@ export const hiddenConfirmDialog = () => ({ visible: false, description: '', onC
 const styles = () => ({
   root: {},
 });
-
-function RateFormat(props) {
-  const { inputRef, onChange, ...other } = props;
-  return (
-    <NumberFormat
-      /* eslint-disable-next-line react/jsx-props-no-spreading */
-      {...other}
-      getInputRef={inputRef}
-      onValueChange={(values) => {
-        onChange({
-          target: {
-            value: values.value,
-          },
-        });
-      }}
-      allowNegative={false}
-      decimalScale={4}
-      fixedDecimalScale
-    />
-  );
-}
 
 function ForexRateEntry(props) {
   const { onCommit } = props;

--- a/src/components/ForexRateEntry.js
+++ b/src/components/ForexRateEntry.js
@@ -4,6 +4,7 @@ import {
   Grid, TextField, Typography, withStyles,
 } from '@material-ui/core';
 import { DateTime } from 'luxon';
+import NumberFormat from 'react-number-format';
 
 import DatePicker from './DatePicker';
 import ForexRateEndDateOption from './ForexRateEndDateOption';
@@ -48,6 +49,27 @@ const styles = () => ({
   root: {},
 });
 
+function RateFormat(props) {
+  const { inputRef, onChange, ...other } = props;
+  return (
+    <NumberFormat
+      /* eslint-disable-next-line react/jsx-props-no-spreading */
+      {...other}
+      getInputRef={inputRef}
+      onValueChange={(values) => {
+        onChange({
+          target: {
+            value: values.value,
+          },
+        });
+      }}
+      allowNegative={false}
+      decimalScale={4}
+      fixedDecimalScale
+    />
+  );
+}
+
 function ForexRateEntry(props) {
   const { onCommit } = props;
   const today830amUTC = DateTime.utc().set({
@@ -64,6 +86,9 @@ function ForexRateEntry(props) {
           margin="normal"
           value={rate}
           variant="outlined"
+          InputProps={{
+            inputComponent: RateFormat,
+          }}
           onChange={(event) => {
             const { value } = event.target;
             if (hasMax4DecimalPlaces(value)) {

--- a/src/components/RateFormat.js
+++ b/src/components/RateFormat.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import NumberFormat from 'react-number-format';
+
+function RateFormat(props) {
+  const { inputRef, onChange, ...other } = props;
+  return (
+    <NumberFormat
+      /* eslint-disable-next-line react/jsx-props-no-spreading */
+      {...other}
+      getInputRef={inputRef}
+      onValueChange={(values) => {
+        onChange({
+          target: {
+            value: values.value,
+          },
+        });
+      }}
+      allowNegative={false}
+      decimalScale={4}
+      fixedDecimalScale
+    />
+  );
+}
+
+RateFormat.propTypes = {
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) })]).isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+export default RateFormat;


### PR DESCRIPTION
This PR can be tested by pointing this UI at an existing backend, navigating to the _Forex Rates_ tab and testing the rate input field.