### PR TITLE
Docker image build that preserves React classes to enable automated testing with the built image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.14.1-alpine AS builder
+FROM node:12.16.1-alpine AS builder
 
 WORKDIR /opt/finance-portal-ui
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,14 @@ FROM node:12.14.1-alpine AS builder
 
 WORKDIR /opt/finance-portal-ui
 
-RUN apk add --no-cache -t build-dependencies git make gcc g++ python libtool autoconf automake \
-    && cd $(npm root -g)/npm \
-    && npm config set unsafe-perm true \
-    && npm install -g node-gyp
-
 COPY package.json package-lock.json* /opt/finance-portal-ui/
 RUN npm ci
+RUN echo yes | npm run eject
 
 COPY ./public/ /opt/finance-portal-ui/public
 COPY ./src/ /opt/finance-portal-ui/src
 
+RUN sed -i 's/keep_\(classnames\|fnames\): isEnvProductionProfile/keep_\1: true/' ./config/webpack.config.js
 RUN npm run build
 
 FROM nginx:alpine

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-portal-web-ui",
-  "version": "9.1.6",
+  "version": "9.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-portal-web-ui",
-  "version": "9.1.6",
+  "version": "9.3.0",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^3.9.2",


### PR DESCRIPTION
Removed redundant build step also.

The testing I did on this wasn't really sufficient. It was to change config and observe that the build size increased. I was hoping it would be apparent that the class names were present but I couldn't tell, because I wasn't really sure what I was looking for. If someone could check that this actually produces the expected result that would be good.