### PR TITLE
Add container image labels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,15 @@ defaults_build_docker_build: &defaults_build_docker_build
 
 defaults_build_docker_build_release: &defaults_build_docker_build_release
   name: Build Docker $RELEASE_TAG image
-  command: |
+  command: >
     echo "Building Docker image: $RELEASE_TAG"
-    docker build -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG .
+
+    docker build
+    --build-arg=BUILD_DATE="$(date -u --iso-8601=seconds)"
+    --build-arg=VERSION="$RELEASE_TAG"
+    --build-arg=VCS_URL="$CIRCLE_REPOSITORY_URL"
+    --build-arg=VCS_REF="$CIRCLE_SHA1"
+    -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG .
 
 defaults_build_docker_publish: &defaults_build_docker_publish
   name: Publish Docker image $CIRCLE_TAG & Latest tag to Docker Hub

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,22 @@ RUN sed -i 's/keep_\(classnames\|fnames\): isEnvProductionProfile/keep_\1: true/
 RUN npm run build
 
 FROM nginx:alpine
+
+ARG BUILD_DATE
+ARG VCS_URL
+ARG VCS_REF
+ARG VERSION
+
+# See http://label-schema.org/rc1/ for label schema info
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="finance-portal-ui"
+LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.vcs-url=$VCS_URL
+LABEL org.label-schema.vcs-ref=$VCS_REF
+LABEL org.label-schema.url="https://mojaloop.io/"
+LABEL org.label-schema.version=$VERSION
+# The base image sets a maintainer label that we override here (it cannot be removed)
+LABEL maintainer=$VCS_URL
+
 COPY --from=builder /opt/finance-portal-ui/build /usr/share/nginx/html
 CMD nginx -g 'daemon off;'


### PR DESCRIPTION
Most importantly this will enable easier retracing of the provenance of
an image. Specifically the `org.label-schema.vcs-ref` and
`org.label-schema.vcs-url` labels. However, the other labels will also
improve the ability to determine provenance for unforeseen users of the
image.

Image labels can be viewed as follows:
```
docker inspect -f '{{json .Config.Labels}}' whatever | jq '.'
```
or, including the line breaks:
```
docker inspect -f '{{ range $k, $v := .Config.Labels -}}
{{ $k }}={{ $v }}
{{ end -}}' $cid
```