### PR TITLE
Fixed the usage of `luxon.DateTime` where the system's timezone was used and being converted  instead of the desired which is `UTC`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-portal-web-ui",
-  "version": "9.3.3",
+  "version": "9.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-portal-web-ui",
-  "version": "9.3.3",
+  "version": "9.3.4",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^3.9.2",

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -4,9 +4,7 @@ import { TextField, withStyles } from '@material-ui/core';
 import { useUIDSeed } from 'react-uid';
 import { DateTime } from 'luxon';
 
-export const strToDate = (datestr) => DateTime.fromFormat(datestr, 'yyyy-MM-dd').toUTC().set({
-  hour: 0, minute: 0, second: 0, millisecond: 0,
-});
+export const strToDate = (datestr) => DateTime.fromFormat(datestr, 'yyyy-MM-dd', { zone: 'UTC' });
 
 // We deliberately lose some information (hh:mm:ss.ms) here. We're just not interested in sub-day
 // granularity.


### PR DESCRIPTION
Example: 
* System timezone: UTC+3
* System time: 19:00:00
* Before this fix: `strToDate('2020-03-06')` would return `2020-03-05T00:00:00.000Z`
* After this fix:  `strToDate('2020-03-06')` returns `2020-03-06T00:00:00.000Z`

The issue was not visible on systems running in UTC timezone.

---

That happened because in the example system above, this:
 ```
DateTime.fromFormat('2020-03-06', 'yyyy-MM-dd').toISO()
```
equals to 
```
2020-03-06T00:00:00.000+03:00
```

so by its turn this 
```
console.log(DateTime.fromFormat('2020-03-06', 'yyyy-MM-dd').toUTC().toISO())
```
equals to
```
2020-03-05T21:00:00.000Z
```