### PR TITLE
Removed the `totalAmount` from Settlement Window details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8911,7 +8911,8 @@
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+      "dev": true
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -10806,6 +10807,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
       "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
       "requires": {
         "min-document": "^2.19.0",
         "process": "^0.11.10"
@@ -13822,6 +13824,7 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
       "requires": {
         "dom-walk": "^0.1.0"
       }
@@ -16460,28 +16463,6 @@
         "shallowequal": "^1.1.0"
       }
     },
-    "react-hot-loader": {
-      "version": "4.12.21",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.21.tgz",
-      "integrity": "sha512-Ynxa6ROfWUeKWsTHxsrL2KMzujxJVPjs385lmB2t5cHUxdoRPGind9F00tOkdc1l5WBleOF4XEAMILY1KPIIDA==",
-      "requires": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
-        }
-      }
-    },
     "react-hotkeys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",
@@ -17616,7 +17597,8 @@
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-portal-web-ui",
-  "version": "9.4.0",
+  "version": "10.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2338,6 +2338,8 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -3751,6 +3753,8 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -4920,6 +4924,144 @@
         }
       }
     },
+    "@testing-library/jest-dom": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.9.0.tgz",
+      "integrity": "sha512-uZ68dyILuM2VL13lGz4ehFEAgxzvLKRu8wQxyAZfejWnyMhmipJ60w4eG81NQikJHBfaYXx+Or8EaPQTDwGfPA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.0.2",
+        "chalk": "^3.0.0",
+        "css": "^2.2.4",
+        "css.escape": "^1.5.1",
+        "jest-diff": "^25.1.0",
+        "jest-matcher-utils": "^25.1.0",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+          "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
+          "integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "jest-diff": "^25.5.0",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          }
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@testing-library/react": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.5.0.tgz",
@@ -5031,6 +5173,125 @@
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
+      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^25.2.1",
+        "pretty-format": "^25.2.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+          "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@types/json-schema": {
@@ -5156,6 +5417,15 @@
       "dev": true,
       "requires": {
         "pretty-format": "^24.3.0"
+      }
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.1.tgz",
+      "integrity": "sha512-yYn5EKHO3MPEMSOrcAb1dLWY+68CG29LiXKsWmmpVHqoP5+ZRiAVLyUHvPNrO2dABDdUGZvavMsaGpWNjM6N2g==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
       }
     },
     "@types/testing-library__react": {
@@ -6807,6 +7077,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -8112,6 +8391,12 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
       "integrity": "sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw=="
     },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
+    },
     "cssdb": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz",
@@ -8626,8 +8911,7 @@
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-      "dev": true
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -9985,6 +10269,12 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -10516,7 +10806,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
       "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "dev": true,
       "requires": {
         "min-document": "^2.19.0",
         "process": "^0.11.10"
@@ -10959,9 +11248,9 @@
       "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
     },
     "http-proxy": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -11907,6 +12196,8 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -13343,9 +13634,9 @@
       }
     },
     "markdown-to-jsx": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.0.tgz",
-      "integrity": "sha512-RH7LCJQ4RFmPqVeZEesKaO1biRzB/k4utoofmTCp3Eiw6D7qfvK8fzZq/2bjEJAtVkfPrM5SMt5APGf2rnaKMg==",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz",
+      "integrity": "sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==",
       "dev": true,
       "requires": {
         "prop-types": "^15.6.2",
@@ -13531,7 +13822,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
       "requires": {
         "dom-walk": "^0.1.0"
       }
@@ -13721,6 +14011,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -16164,6 +16460,28 @@
         "shallowequal": "^1.1.0"
       }
     },
+    "react-hot-loader": {
+      "version": "4.12.21",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.21.tgz",
+      "integrity": "sha512-Ynxa6ROfWUeKWsTHxsrL2KMzujxJVPjs385lmB2t5cHUxdoRPGind9F00tOkdc1l5WBleOF4XEAMILY1KPIIDA==",
+      "requires": {
+        "fast-levenshtein": "^2.0.6",
+        "global": "^4.3.0",
+        "hoist-non-react-statics": "^3.3.0",
+        "loader-utils": "^1.1.0",
+        "prop-types": "^15.6.1",
+        "react-lifecycles-compat": "^3.0.4",
+        "shallowequal": "^1.1.0",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        }
+      }
+    },
     "react-hotkeys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",
@@ -16499,6 +16817,16 @@
       "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
       "requires": {
         "minimatch": "3.0.4"
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
       }
     },
     "refractor": {
@@ -17288,8 +17616,7 @@
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "dev": true
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -18949,6 +19276,8 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -19723,6 +20052,8 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
-    "react-hot-loader": "^4.12.21",
     "react-jss": "^8.6.1",
     "react-number-format": "^4.0.7",
     "react-scripts": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,20 @@
 {
   "name": "admin-portal-web-ui",
-  "version": "9.4.0",
-  "private": true,
+  "version": "10.3.0",
+  "license": "Apache-2.0",
+  "contributors": [
+    "Matt Kingston <matt.kingston@modusbox.com>",
+    "Kamuela Franco <kamuela.franco@modusbox.com>",
+    "Aarón Reynoza <aaron.reynoza@modusbox.com>",
+    "Vassilis Barzokas <vassilis.barzokas@modusbox.com>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mojaloop/finance-portal-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mojaloop/finance-portal-ui/issues"
+  },
   "dependencies": {
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^3.0.2",
@@ -13,6 +26,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
+    "react-hot-loader": "^4.12.21",
     "react-jss": "^8.6.1",
     "react-number-format": "^4.0.7",
     "react-scripts": "^3.3.0",
@@ -43,6 +57,7 @@
     "@storybook/addons": "^5.3.13",
     "@storybook/preset-create-react-app": "^1.5.2",
     "@storybook/react": "^5.3.17",
+    "@testing-library/jest-dom": "^5.9.0",
     "@testing-library/react": "^9.4.0",
     "eslint": "^6.6.0",
     "eslint-config-airbnb": "^18.0.1",

--- a/src/__tests__/SettlementWindowTransfersTab.test.js
+++ b/src/__tests__/SettlementWindowTransfersTab.test.js
@@ -1,92 +1,160 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import SettlementWindowTransfersTab from '../components/SettlementWindowTransfersTab';
 
 const settlementWindowDetails = {
   settlementWindow: {
     settlementWindowId: 93,
     settlementWindowStateId: 'PENDING_SETTLEMENT',
-    amount: '350.9700',
-    currencyId: 'EUR,MAD',
+    amount: '1116.8200',
+    currencyId: 'EUR,MAD,UGX,ZMW,RWF,GHS',
     settlementWindowOpen: '2020-02-26T20:42:03.000Z',
     settlementWindowClose: '2020-02-26T20:42:10.000Z',
   },
   participantAmount: [
     {
       fspId: 'DFSPEUR',
-      inAmount: '-27.0000',
       currency: 'EUR',
-      outAmount: 0,
-      netAmount: '-27.0000',
+      inAmount: '-20.4800',
+      outAmount: '0',
+      netAmount: '-20.4800',
     },
     {
       fspId: 'DFSPMAD',
-      inAmount: 0,
       currency: 'MAD',
-      outAmount: '323.9700',
-      netAmount: '323.9700',
+      inAmount: '0',
+      outAmount: '110.7700',
+      netAmount: '110.7700',
+    },
+    {
+      fspId: 'DFSPUGX',
+      currency: 'UGX',
+      inAmount: '-1082.0000',
+      outAmount: '259.0000',
+      netAmount: '-823.0000',
+    },
+    {
+      fspId: 'DFSPZMW',
+      currency: 'ZMW',
+      inAmount: '-21.1900',
+      outAmount: '11.9400',
+      netAmount: '-9.2500',
+    },
+    {
+      fspId: 'DFSPRWF',
+      currency: 'RWF',
+      inAmount: '-49.0000',
+      outAmount: '64.0000',
+      netAmount: '15.0000',
+    },
+    {
+      fspId: 'DFSPGHS',
+      currency: 'GHS',
+      inAmount: '0',
+      outAmount: '6.3200',
+      netAmount: '6.3200',
+    },
+    {
+      fspId: 'noresponsepayeefsp',
+      currency: 'XOF',
+      inAmount: '-11.0000',
+      outAmount: '0',
+      netAmount: '-11.0000',
+    },
+    {
+      fspId: 'payeefsp',
+      currency: 'XOF',
+      inAmount: '-1.0000',
+      outAmount: '0',
+      netAmount: '-1.0000',
+    },
+    {
+      fspId: 'payerfsp',
+      currency: 'XOF',
+      inAmount: '0',
+      outAmount: '12.0000',
+      netAmount: '12.0000',
+    },
+    {
+      fspId: 'testfsp1',
+      currency: 'XOF',
+      inAmount: '0',
+      outAmount: '120.0000',
+      netAmount: '120.0000',
+    },
+    {
+      fspId: 'testfsp2',
+      currency: 'XOF',
+      inAmount: '-120.0000',
+      outAmount: '0',
+      netAmount: '-120.0000',
     },
     {
       fspId: 'testfsp3',
-      inAmount: 0,
       currency: 'EUR',
-      outAmount: '27.0000',
-      netAmount: '27.0000',
+      inAmount: '0',
+      outAmount: '20.4800',
+      netAmount: '20.4800',
     },
     {
       fspId: 'testfsp4',
-      inAmount: '-323.9700',
       currency: 'MAD',
-      outAmount: 0,
-      netAmount: '-323.9700',
+      inAmount: '-110.7700',
+      outAmount: '0',
+      netAmount: '-110.7700',
+    },
+    {
+      fspId: 'testfsp5',
+      currency: 'UGX',
+      inAmount: '-259.0000',
+      outAmount: '1082.0000',
+      netAmount: '823.0000',
+    },
+    {
+      fspId: 'testfsp6',
+      currency: 'ZMW',
+      inAmount: '-11.9400',
+      outAmount: '21.1900',
+      netAmount: '9.2500',
+    },
+    {
+      inAmount: '-64.0000',
+      fspId: 'testfsp7',
+      currency: 'RWF',
+      outAmount: '49.0000',
+      netAmount: '-15.0000',
+    },
+    {
+      fspId: 'testfsp8',
+      currency: 'GHS',
+      inAmount: '-6.3200',
+      outAmount: '0',
+      netAmount: '-6.3200',
     },
   ],
   totalAmount: [
     {
-      EUR: '27.0000',
+      XOF: '132.0000',
     },
     {
-      MAD: '323.9700',
-    },
-  ],
-  settlementId: 93,
-  relatedSettlementWindows: [],
-  settlement: {},
-};
-
-const settlementWindowDetailsOneTransfer = {
-  settlementWindow: {
-    settlementWindowId: 93,
-    settlementWindowStateId: 'PENDING_SETTLEMENT',
-    amount: '350.9700',
-    currencyId: 'EUR,MAD',
-    settlementWindowOpen: '2020-02-26T20:42:03.000Z',
-    settlementWindowClose: '2020-02-26T20:42:10.000Z',
-  },
-  participantAmount: [
-    {
-      fspId: 'testfsp3',
-      inAmount: 0,
-      currency: 'EUR',
-      outAmount: '27.0000',
-      netAmount: '27.0000',
+      EUR: '20.4800',
     },
     {
-      fspId: 'testfsp4',
-      inAmount: '-323.9700',
-      currency: 'MAD',
-      outAmount: 0,
-      netAmount: '-323.9700',
-    },
-  ],
-  totalAmount: [
-    {
-      EUR: '27.0000',
+      MAD: '0.0000',
     },
     {
-      MAD: '323.9700',
+      UGX: '1082.0000',
     },
-  ],
+    {
+      ZMW: '21.1900',
+    },
+    {
+      RWF: '49.0000',
+    },
+    {
+      GHS: '0.0000',
+    }],
   settlementId: 93,
   relatedSettlementWindows: [],
   settlement: {},
@@ -96,65 +164,53 @@ const classes = {
   tableDetails: '',
 };
 
+const columnHeaders = ['FSP ID', 'Currency', 'In Amount', 'Out Amount', 'Net Amount'];
+
 describe('<SettlementWindowTransfersTab />', async () => {
-  it('should not render without props', () => {
+  it('should not render if the property `settlementWindowDetails` is not defined.', () => {
     const { queryByText } = render(
       <SettlementWindowTransfersTab />,
     );
-    expect(queryByText('Currency')).toBe(null);
+
+    columnHeaders.forEach((columnHeader) => {
+      expect(queryByText(columnHeader)).toBe(null);
+      expect(queryByText(columnHeader)).toBeDefined();
+    });
   });
 
-  it('should render with props', () => {
+  it('should render if the property `settlementWindowDetails` is defined.', () => {
     const { queryByText } = render(
       <SettlementWindowTransfersTab
         settlementWindowDetails={settlementWindowDetails}
         classes={classes}
       />,
     );
-    const element = queryByText('Currency');
-    expect(element).toBeDefined();
+
+    columnHeaders.forEach((columnHeader) => {
+      expect(queryByText(columnHeader)).not.toBe(null);
+      expect(queryByText(columnHeader)).toBeDefined();
+    });
   });
 
-  it('should have the right amount of transfers', () => {
-    const { queryAllByText } = render(
-      <SettlementWindowTransfersTab
-        settlementWindowDetails={settlementWindowDetails}
-        classes={classes}
-      />,
-    );
-    const transfersEUR = queryAllByText('EUR');
-    const transfersMAD = queryAllByText('MAD');
-    expect(transfersEUR.length).toBe(2);
-    expect(transfersMAD.length).toBe(2);
-  });
+  it('should render all transfers with the correct amounts.', () => {
+    render(<SettlementWindowTransfersTab
+      settlementWindowDetails={settlementWindowDetails}
+      classes={classes}
+    />);
 
-  it('should display the correct amount for a transfer', () => {
-    const { queryAllByText } = render(
-      <SettlementWindowTransfersTab
-        settlementWindowDetails={settlementWindowDetails}
-        classes={classes}
-      />,
-    );
-    const transfersEUR = queryAllByText('-323.9700');
-    const transfersMAD = queryAllByText('-27.0000');
-    expect(transfersEUR.length).toBe(2);
-    expect(transfersMAD.length).toBe(2);
-  });
+    settlementWindowDetails.participantAmount.forEach((item) => {
+      // the FSP ID appears only once
+      expect(screen.getAllByText(item.fspId).length).toBe(1);
 
-  it('should render all rows', () => {
-    const { queryAllByText } = render(
-      <SettlementWindowTransfersTab
-        settlementWindowDetails={settlementWindowDetailsOneTransfer}
-        classes={classes}
-      />,
-    );
-    const fspID = queryAllByText('testfsp3');
-    const fspCurrency = queryAllByText('EUR');
-    const fspOutAmount = queryAllByText('27.0000');
-    const fspInAmount = queryAllByText('0');
-    expect(fspOutAmount.length).toBe(2); // We're also counting net amount.
-    expect(fspID.length).toBe(1);
-    expect(fspCurrency.length).toBe(1);
-    expect(fspInAmount.length).toBe(2); // we also count the other fsp outAmount(0)
+      // get the row of that FSP ID
+      const row = screen.getByText(item.fspId).closest('tr');
+
+      // verify that the columns of the row display the expected values
+      expect(row.cells[0]).toHaveTextContent(item.fspId);
+      expect(row.cells[1]).toHaveTextContent(item.currency);
+      expect(row.cells[2]).toHaveTextContent(item.inAmount);
+      expect(row.cells[3]).toHaveTextContent(item.outAmount);
+      expect(row.cells[4]).toHaveTextContent(item.netAmount);
+    });
   });
 });

--- a/src/components/SettlementWindowsTab.js
+++ b/src/components/SettlementWindowsTab.js
@@ -266,16 +266,6 @@ function SettlementWindowsGrid(props) {
                   </Paper>
                 </Grid>
               </Grid>
-              {settlementWindowDetails.totalAmount.map((currency) => (
-                <Grid container spacing={8} key={Object.keys(currency)[0]}>
-                  <Grid item md={6}><Paper className={classes.paper}>Total Amount</Paper></Grid>
-                  <Grid item md={6}>
-                    <Paper className={classes.paper}>
-                      {`${currency[Object.keys(currency)[0]]} ${Object.keys(currency)[0]}`}
-                    </Paper>
-                  </Grid>
-                </Grid>
-              ))}
               <Grid container spacing={8}>
                 <Grid item md={6}>
                   <Paper className={classes.paper}>Start DateTime</Paper>


### PR DESCRIPTION
Removed the `totalAmount` from Settlement Window details as it is a sales figure not finance figure and takes up inordinate amount of space on the page;
Updated unit tests to ensure that the multi currency transfers display properly in the Settlement Window details;
Added license and contributors list;
Bumped to v10.3.0.